### PR TITLE
Change Chapter 3 for Riolu to evolve to Lucario

### DIFF
--- a/story.html
+++ b/story.html
@@ -41,11 +41,11 @@
 </p>
 <p>
 	II. Shadow starts his journey off with a rough start, having to pull Riolu
-	up a hill with a rope. Eventually he gets fed up and unties it, asking it
+	up a hill with a rope. Eventually, he gets fed up and unties it, asking it
 	to walk with him, but it still doesn't like him. Shadow attempts to catch a
-	Pidgey with a rock, since Riolu refuses to help, but instead hits a Spearow
+	Pidgey with a rock since Riolu refuses to help but instead hits a Spearow
 	that aggresses Riolu. After fending it off, a swarm of a thousand Spearow
-	begin attacking them, and Shadow carries a battered Riolu until he falls
+	begins attacking them, and Shadow carries a battered Riolu until he falls
 	into a ditch. Prepared to take the full front of the storm for Riolu,
 	Shadow stands up to face them, but just before they attack, Riolu jumps up
 	and scatters them away with a blast of Aura. The two realize the
@@ -91,43 +91,44 @@
 	III.
 	<em>
 		Time fast-forwards, a lot. Shadow now has two gym badges and is
-		currently in the middle of getting his third.
+		currently in the middle of getting his third from the Celadon Gym.
 	</em>
-	After defeating the third Gym leader, Riolu evolves into a Lucario. Shadow
-	then catches a Caterpie in the wild, then goes to a Pok&#233;mon Center to
-	heal his Pok&#233;mon and talk to his dad. He gets word that Entei is near
-	and hangs up to go search for it. He comes across Verity who also wants to
-	battle it, as well as Sorrel. None of them phase it, and Entei walks away
-	unharmed. Shadow and Verity blame each other for letting Entei escape and
-	battle while Sorrel walks away, claiming that it will rain soon. The former
-	two disturb an Onyx that chases them until Shadow manages to calm it down.
-	It then starts raining, and Shadow and Verity start searching for shelter
-	before coming across a Charmander that had been abandoned by Cross. Shadow
-	takes Charmander, and he and Verity find a cave where Sorrel also happens
-	to be. After treating Charmander, the three Trainers begin to talk about
-	themselves until Entei walks into the cave with other wild Pok&#233;mon and
-	rests on another platform. Sorrel brings up the myth about Ho-Oh and the
-	legendary trio (Entei, Raikou, and Suicune), and when Shadow takes out the
-	Rainbow Wing, everyone is amazed. The three then agree to travel to Mount
-	Tensei, where Ho-Oh resides.
+	After defeating Erika, Riolu evolves into a Lucario and Shadow receives his
+	third badge. Shadow then catches a Caterpie in the wild, then goes to a
+	Pok&#233;mon Center to heal his Pok&#233;mon and talk to his dad. He gets
+	word that Entei is near and hangs up to go search for it. He comes across
+	Verity who also wants to battle it, as well as Sorrel. None of them phase
+	it, and Entei walks away unharmed. Shadow and Verity blame each other for
+	letting Entei escape and battle while Sorrel walks away, claiming that it
+	will rain soon. The former two disturb an Onyx that chases them until
+	Shadow manages to calm it down. It then starts raining, and Shadow and
+	Verity start searching for shelter before coming across a Charmander that
+	had been abandoned by Cross. Shadow takes Charmander, and he and Verity
+	find a cave where Sorrel also happens to be. After treating Charmander, the
+	three Trainers begin to talk about themselves until Entei walks into the
+	cave with other wild Pok&#233;mon and rests on another platform. Sorrel
+	brings up the myth about Ho-Oh and the legendary trio (Entei, Raikou, and
+	Suicune), and when Shadow takes out the Rainbow Wing, everyone is amazed.
+	The three then agree to travel to Mount Tensei, where Ho-Oh resides.
 </p>
 <p>
-	a) Shadow is in the middle of an intense battle with the third gym leader
-	of his journey. After defeating her, Riolu unexpectedly evolves into
-	Lucario, and the two high five afterwards. They then start walking towards
-	a Pok&#233;mon Center and detour towards a forest. While walking, Shadow
-	spots a Caterpie that becomes quickly hostile to him. After a quick battle,
-	Shadow captures Caterpie and starts walking to a Pok&#233;mon Center where
-	he heals his Pok&#233;mon and phones his dad. The latter is merely
-	concerned about Shadow's wellbeing, and Shadow quickly loses his patience.
-	Nurse Joy comes out of her back room and informs Shadow that Riolu has been
-	healed; it is on top of a cart that Nurse Joy's Chansey is carrying. Riolu
-	climbs up onto Shadow's shoulder and says hello. As they're talking, a
-	different Trainer with a Vaporeon appears and talks about having battled
-	Entei a few minutes ago. Shadow says a hasty goodbye to his dad and exits
-	the Pok&#233;mon Center; other trainers exit as well; they're all looking
-	for Entei. After some searching in the forest, Shadow sees Entei standing
-	on top of a rock in a clearing. However, to his right is another trainer:
+	a) Shadow is in the middle of an intense battle with Erika, the third Gym
+	leader of his journey. After defeating her Tangela, Riolu unexpectedly
+	evolves into Lucario, and the two high five after Shadow officially
+	receives his third badge. They then start walking towards a Pok&#233;mon
+	Center and detour towards a forest. While walking, Shadow spots a Caterpie
+	that becomes quickly hostile to him. After a quick battle, Shadow captures
+	Caterpie and starts continues to the Pok&#233;mon Center, where he heals
+	his Pok&#233;mon and phones his dad. The latter is merely concerned about
+	Shadow's wellbeing, and Shadow quickly loses his patience. Nurse Joy comes
+	out of her back room and informs Shadow that Lucario has been healed; it is
+	on top of a cart that Nurse Joy's Chansey is carrying. Lucario climbs up
+	onto Shadow's shoulder and says hello. As they're talking, a different
+	Trainer with a Vaporeon appears and talks about having battled Entei a few
+	minutes ago. Shadow says a hasty goodbye to his dad and exits the
+	Pok&#233;mon Center; other trainers exit as well; they're all looking for
+	Entei. After some searching in the forest, Shadow sees Entei standing on
+	top of a rock in a clearing. However, to his right is another trainer:
 	Verity! Armed with a Piplup, she too wants to fight Entei and the two race
 	to the clearing in hopes of being the first to battle. Once they make it,
 	though, they see a third trainer, named Sorrel, with a Lucario on the other
@@ -136,8 +137,8 @@
 	accusing each other of being the reason Entei fled, and the two agree to a
 	battle. Sorrel, on the other hand, refuses to fight, and leaves with his
 	Lucario, telling them that it's due to rain soon. Verity's Piplup's Hydro
-	Pump misses Riolu and instead hits what was thought to be rocks outside of
-	the clearing, but to both of their horror, an Onyx rises, maddened. Both
+	Pump misses Lucario and instead hits what was thought to be rocks outside
+	of the clearing, but to both of their horror, an Onyx rises, maddened. Both
 	Trainers and their Pok&#233;mon flee the scene, and after a long chase
 	through a rock ravine Shadow manages to calm the Onyx down. True enough, it
 	begins raining, and Shadow and Verity decide to find shelter together. On
@@ -167,7 +168,7 @@
 	taking particular notice of Shadow's Rainbow Wing. The three leave it
 	alone, and Sorrel says that it's going to be cold despite the existence of
 	a fire. He puts his Lucario back into its Pok&#233;ball, as does Verity
-	with Piplup, but Shadow explains that Riolu does not appreciate being in
+	with Piplup, but Shadow explains that Lucario does not appreciate being in
 	its Pok&#233;ball. The other two Pok&#233;mon hop out of their
 	Pok&#233;balls as well, and they all spend the night sleeping together.
 </p>
@@ -183,14 +184,14 @@
 	Incineroar. Shadow uses Charmeleon, believing that he could win through the
 	sheer faith that Cross' training strategy is incorrect. However, Charmeleon
 	is savagely beaten, and Shadow is unable to believe the loss, openly
-	admitting afterward that had he used Riolu he would have won. He runs away
-	into the forest and Sorrel and Verity cannot catch up, and when Riolu
-	disagrees with him as well it stops following. Shadow sits down on a tree,
-	questioning if he is the rainbow hero before Marshadow puts him in a
-	trance-like state. Beside him, the Rainbow Wing loses its color.
+	admitting afterward that had he used Lucario he would have won. He runs
+	away into the forest and Sorrel and Verity cannot catch up, and when
+	Lucario disagrees with him as well it stops following. Shadow sits down on
+	a tree, questioning if he is the rainbow hero before Marshadow puts him in
+	a trance-like state. Beside him, the Rainbow Wing loses its color.
 </p>
 <p>
-	a) Riolu is the first to wake up the following morning and immediately
+	a) Lucario is the first to wake up the following morning and immediately
 	notices that the rain has stopped and that Entei has gone. The others start
 	waking up and when Shadow awakes he sees that Charmander's tail flame is
 	back to full strength. Shadow asks Charmander if it would like to go with
@@ -221,25 +222,25 @@
 	cheap friendship and tried to use moves he couldn't use. Shadow has no
 	retort. He can't believe his loss and is extremely upset despite Verity's
 	and Sorrel's attempts to console him. He openly admits that he would have
-	won had he used Riolu instead, and runs away into the forest when Sorrel
+	won had he used Lucario instead, and runs away into the forest when Sorrel
 	calls him out on being no better than Cross if that was his mindset. The
-	others chase him, but Riolu is the only one who keeps pace; Verity and
+	others chase him, but Lucario is the only one who keeps pace; Verity and
 	Sorrel are left behind. Eventually, Shadow slows to a walk, still walking
-	away, and declares the two losers. He asks if Riolu agrees with him, to
+	away, and declares the two losers. He asks if Lucario agrees with him, to
 	which it says no. Shadow says that he wishes that he had chosen Bulbasaur
-	or Squirtle instead. Riolu stops following Shadow and stands while the
+	or Squirtle instead. Lucario stops following Shadow and stands while the
 	latter continues walking away until it is out of sight. When Shadow glances
 	back, it is completely gone. Sitting down against a tree, he questions
-	whether or not he even needs Riolu, and sits down against a tree. He takes
-	out the Rainbow Wing and says to Ho-Oh that he thought he was the rainbow
-	hero. Marshadow slowly appears from behind Shadow (he doesn't notice it)
-	and possesses him, giving his eyes a purple glow and putting him into a
-	sleep-like state. The Rainbow Wing falls out of Shadow's hand and is
+	whether or not he even needs Lucario, and sits down against a tree. He
+	takes out the Rainbow Wing and says to Ho-Oh that he thought he was the
+	rainbow hero. Marshadow slowly appears from behind Shadow (he doesn't
+	notice it) and possesses him, giving his eyes a purple glow and putting him
+	into a sleep-like state. The Rainbow Wing falls out of Shadow's hand and is
 	corrupted, losing its color.
 </p>
 <p>
 	V. Shadow wakes up late to the first day of school, and once he makes it he
-	find out he is the latest of the four people to be late. During class, he
+	finds out he is the latest of the four people to be late. During class, he
 	is distracted by blurs of things in his peripherals. Once class ends, he
 	goes to the rooftop, where he confides to Verity and Sorrel that he wants
 	to see what is "out there"; he wants to go on a journey. He says that he
@@ -247,12 +248,12 @@
 	exists, and Verity and Sorrel disappear as he starts to cry. After seeing a
 	vision of his partner, Shadow begins running toward it, running first
 	through a plaza and then jumping across the ground as the world begins to
-	crumble apart. After catching it mid-air, he remembers its name, Riolu, and
-	then wakes up under the tree where he fell asleep. In front of him is Riolu
-	looking concerned, and he hugs it, apologizing profusely and saying that it
-	was all his fault. Besides him, the Rainbow Wing regains its color, and
-	Verity and Sorrel begin reprimand him. After doing so, Shadow gets up and
-	together they move to elsewhere in the forest.
+	crumble apart. After catching it mid-air, he remembers its name, Lucario,
+	and then wakes up under the tree where he fell asleep. In front of him is
+	Lucario looking concerned, and he hugs it, apologizing profusely and saying
+	that it was all his fault. Besides him, the Rainbow Wing regains its color,
+	and Verity and Sorrel begin to reprimand him. After doing so, Shadow gets
+	up and together they move to elsewhere in the forest.
 </p>
 <p>
 	a) Shadow is sleeping in bed, and in a dream throws his alarm clock,
@@ -284,16 +285,16 @@
 	towards it, and he suddenly finds himself running along a plaza. He says
 	that they used to run like this all the time. The ground starts crumbling
 	into chunks and falling into the void, and Shadow tries to catch up. He
-	jumps and catches his partner, remembering its name, Riolu. Suddenly, the
+	jumps and catches his partner, remembering its name, Lucario. Suddenly, the
 	two are transported to the skies above a meadow and fall to the ground in
 	terror. When Shadow hits the ground, he wakes up in the waking world, still
-	underneath the tree. He immediately sees Riolu in front of him and hugs it,
-	crying and saying that it was all his fault. Beside him, the Rainbow Wing
-	regains its color. Verity asks Shadow if he had any idea how long they'd
-	been searching for him, and Sorrel lectures him, saying that you cannot
-	expect to win every battle and that it's the losses that you grow strong
-	from, but that's just his opinion. Shadow gets up, and the group goes
-	elsewhere in the forest.
+	underneath the tree. He immediately sees Lucario in front of him and hugs
+	it, crying and saying that it was all his fault. Beside him, the Rainbow
+	Wing regains its color. Verity asks Shadow if he had any idea how long
+	they'd been searching for him, and Sorrel lectures him, saying that you
+	cannot expect to win every battle and that it's the losses that you grow
+	strong from, but that's just his opinion. Shadow gets up, and the group
+	goes elsewhere in the forest.
 </p>
 <p>
 	VI. As the group makes a camp in the forest, Shadow tells about the dream
@@ -304,9 +305,9 @@
 	the snow, and Luxray found him and curled up next to him to keep him warm.
 	When morning came, Luxray was frozen solid. A rescue team then found
 	Sorrel, and while he was being dragged away he was screaming Luxray's name.
-	Marshadow suddenly appears behind Shadow and is noticed. Riolu fires an
+	Marshadow suddenly appears behind Shadow and is noticed. Lucario fires an
 	Aura Sphere at the spot where Marshadow was, but it had already rescinded
-	into Shadow's shadow; instead, Riolu hits a tree, triggering a group of
+	into Shadow's shadow; instead, Lucario hits a tree, triggering a group of
 	Primape to come down. The Primape get in a circle and begin throwing the
 	group in the air until Sorrel advises Shadow to use Metapod to calm them.
 	Shadow gets off and has Metapod use String Shot to stop the Primape, at
@@ -331,7 +332,7 @@
 	reluctant to make friends with any Pok&#233;mon, until he found Lucario.
 	Shadow and Verity are somber after hearing the tale and offer their
 	condolences. Meanwhile, Marshadow slowly appears from Shadow's shadow, but
-	this time they spot it. Riolu is instantly aggressive and fires an Aura
+	this time they spot it. Lucario is instantly aggressive and fires an Aura
 	Sphere at Marshadow's location, but it rescinds long before it would have
 	hit. Instead, the Aura Sphere hits the tree and shakes it. A group of
 	Primape come down from the branches and quickly gather the team in a
@@ -418,7 +419,7 @@
 	he's been on a quest to find Ho-Oh and that all of the data he's gathered
 	points to Mount Tensei being the next place that Ho-Oh will be. They all
 	start walking towards the summit of the mountain, and once it's visible the
-	Rainbow Wing beams another flash of light that lights up the ahead area.
+	Rainbow Wing beams another flash of light that lights up the area ahead.
 	Shadow runs ahead, excited. <strong>/</strong> At the summit, more
 	Pok&#233;mon are gathered around, and Rainbow Rock is at the other end of a
 	circular battlefield. Shadow slowly walks over to it to put the Rainbow
@@ -606,25 +607,25 @@ and Marshadow engage in a fierce battle for the Rainbow Wing	<em>(see scene desc
 	asks it to get into its Pok&#233;ball where it'd be protected. He leaves it
 	and stands up to face the encroaching Pok&#233;mon, who are charging an
 	attack. He taunts them with the same phrase he said against the Spearow
-	swarm; as soon as he finishes, the Pok&#233;mon fire, and Lucario jumps
+	swarm; as soon as he finishes, the Pok&#233;mon fire and Lucario jumps
 	ahead to protect Shadow. Shadow stops it and buries it in his arms to
-	protect it, and when the blast hits the two are knocked onto the ground
-	next to each other. Upon asking why Lucario wouldn't get into its
-	Pok&#233;ball, it replies in English, "It's because&#8230;It's because I
-	always want&#8230;to be with you." The mind-controlled Pok&#233;mon fire
-	one more shot, and Shadow forces Lucario into its Pok&#233;ball and holds
-	it tightly next to him. The explosion created is visible from many miles
-	away, and the rest of the group gathers to watch. When the smoke clears,
-	Lucario's Pok&#233;ball rolls away and Shadow's hat lands on top of it;
-	when Lucario comes out of it, it's wearing the hat. In front of it is
-	Shadow's body, energy flowing from it. The Rainbow Wing begins to
-	disintegrate in Marshadow's hand. Lucario attempts to place Shadow's hat on
-	his body, but once it does the body disappears into nothing; the Rainbow
-	Wing vanishes as well. Lucario buries Shadow's hat in its face and cries
-	out, unleashing a blast of Aura that engulfs everything on the mountain; it
-	is so strong that the clouds fade and reveal a blue sky. The opposing
-	Pok&#233;mon are no longer mind-controlled, and everybody looks at Lucario,
-	crying into the hat. It shouts into the heavens one more time.
+	protect it, and when the blast hits the two are knocked to the ground next
+	to each other. Upon asking why Lucario wouldn't get into its Pok&#233;ball,
+	it replies in English, "It's because&#8230;It's because I always
+	want&#8230;to be with you." The mind-controlled Pok&#233;mon fire one more
+	shot, and Shadow forces Lucario into its Pok&#233;ball and holds it tightly
+	next to him. The explosion created is visible from many miles away, and the
+	rest of the group gathers to watch. When the smoke clears, Lucario's
+	Pok&#233;ball rolls away and Shadow's hat lands on top of it; when Lucario
+	comes out of it, it's wearing the hat. In front of it is Shadow's body,
+	energy flowing from it. The Rainbow Wing begins to disintegrate in
+	Marshadow's hand. Lucario attempts to place Shadow's hat on his body, but
+	once it does the body disappears into nothing; the Rainbow Wing vanishes as
+	well. Lucario buries Shadow's hat in its face and cries out, unleashing a
+	blast of Aura that engulfs everything on the mountain; it is so strong that
+	the clouds fade and reveal a blue sky. The opposing Pok&#233;mon are no
+	longer mind-controlled, and everybody looks at Lucario, crying into the
+	hat. It shouts into the heavens one more time.
 </p>
 <p>
 	a) Shadow immediately gets back up to see Lucario lying on the ground a few
@@ -737,10 +738,10 @@ and Marshadow engage in a fierce battle for the Rainbow Wing	<em>(see scene desc
 	healed. Once it is, Cross parts ways with them outside, vowing to battle
 Shadow again and telling him not to lose to anyone until then.	<strong>/ </strong>At the top of a hill with a tree, where four paths meet,
 	the group itself dissolves. Sorrel says that he'll be learning about the
-	legendary bird trio, Verity plans to see her mother in Sinnoh, and Shadow
-	of course continues striving to be a Pok&#233;mon master. Sorrel hopes that
-	they will meet again one day, and the three say in unison, "Then we'll have
-	a battle!" before walking their separate ways.
+	legendary bird trio, Verity plans to see her mother in Sinnoh, and Shadow,
+	of course, continues striving to be a Pok&#233;mon master. Sorrel hopes
+	that they will meet again one day, and the three say in unison, "Then we'll
+	have a battle!" before walking their separate ways.
 </p>
 <p>
 	a) The group arrives at the nearest Pok&#233;mon Center, and Shadow goes to

--- a/story.html
+++ b/story.html
@@ -90,46 +90,49 @@
 <p>
 	III.
 	<em>
-		Time fast-forwards, a lot. Shadow now has three Gym badges, and his
-		bond with Riolu has strengthened immensely (although it hasn't evolved
-		yet).
+		Time fast-forwards, a lot. Shadow now has two gym badges and is
+		currently in the middle of getting his third.
 	</em>
-	Shadow catches a Caterpie in the wild, then goes to a Pok&#233;mon Center
-	to heal his Pok&#233;mon and talk to his dad. He gets word that Entei is
-	near and hangs up to go search for it. He comes across Verity who also
-	wants to battle it, as well as Sorrel. None of them phase it, and Entei
-	walks away unharmed. Shadow and Verity blame each other for letting Entei
-	escape and battle while Sorrel walks away, claiming that it will rain soon.
-	The former two disturb an Onyx that chases them until Shadow manages to
-	calm it down. It then starts raining, and Shadow and Verity start searching
-	for shelter before coming across a Charmander that had been abandoned by
-	Cross. Shadow takes Charmander, and he and Verity find a cave where Sorrel
-	also happens to be. After treating Charmander, the three Trainers begin to
-	talk about themselves until Entei walks into the cave with other wild
-	Pok&#233;mon and rests on another platform. Sorrel brings up the myth about
-	Ho-Oh and the legendary trio (Entei, Raikou, and Suicune), and when Shadow
-	takes out the Rainbow Wing, everyone is amazed. The three then agree to
-	travel to Mount Tensei, where Ho-Oh resides.
+	After defeating the third Gym leader, Riolu evolves into a Lucario. Shadow
+	then catches a Caterpie in the wild, then goes to a Pok&#233;mon Center to
+	heal his Pok&#233;mon and talk to his dad. He gets word that Entei is near
+	and hangs up to go search for it. He comes across Verity who also wants to
+	battle it, as well as Sorrel. None of them phase it, and Entei walks away
+	unharmed. Shadow and Verity blame each other for letting Entei escape and
+	battle while Sorrel walks away, claiming that it will rain soon. The former
+	two disturb an Onyx that chases them until Shadow manages to calm it down.
+	It then starts raining, and Shadow and Verity start searching for shelter
+	before coming across a Charmander that had been abandoned by Cross. Shadow
+	takes Charmander, and he and Verity find a cave where Sorrel also happens
+	to be. After treating Charmander, the three Trainers begin to talk about
+	themselves until Entei walks into the cave with other wild Pok&#233;mon and
+	rests on another platform. Sorrel brings up the myth about Ho-Oh and the
+	legendary trio (Entei, Raikou, and Suicune), and when Shadow takes out the
+	Rainbow Wing, everyone is amazed. The three then agree to travel to Mount
+	Tensei, where Ho-Oh resides.
 </p>
 <p>
-	a) Shadow is out in the wild, walking along a path with Riolu. Up in the
-	trees, however, is a Caterpie that becomes quickly hostile to him. After a
-	quick battle, Shadow captures Caterpie and starts walking to a Pok&#233;mon
-	Center where he heals his Pok&#233;mon and phones his dad. The latter is
-	merely concerned about Shadow's wellbeing, and Shadow quickly loses his
-	patience. Nurse Joy comes out of her back room and informs Shadow that
-	Riolu has been healed; it is on top of a cart that Nurse Joy's Chansey is
-	carrying. Riolu climbs up onto Shadow's shoulder and says hello. As they're
-	talking, a different Trainer with a Vaporeon appears and talks about having
-	battled Entei a few minutes ago. Shadow says a hasty goodbye to his dad and
-	exits the Pok&#233;mon Center; other trainers exit as well; they're all
-	looking for Entei. After some searching in the forest, Shadow sees Entei
-	standing on top of a rock in a clearing. However, to his right is another
-	trainer: Verity! Armed with a Piplup, she too wants to fight Entei and the
-	two race to the clearing in hopes of being the first to battle. Once they
-	make it, though, they see a third trainer, named Sorrel, with a Lucario on
-	the other side of the clearing. All three of them try to fight Entei, but
-	Entei disdains the attack and flees to elsewhere. Shadow and Verity argue,
+	a) Shadow is in the middle of an intense battle with the third gym leader
+	of his journey. After defeating her, Riolu unexpectedly evolves into
+	Lucario, and the two high five afterwards. They then start walking towards
+	a Pok&#233;mon Center and detour towards a forest. While walking, Shadow
+	spots a Caterpie that becomes quickly hostile to him. After a quick battle,
+	Shadow captures Caterpie and starts walking to a Pok&#233;mon Center where
+	he heals his Pok&#233;mon and phones his dad. The latter is merely
+	concerned about Shadow's wellbeing, and Shadow quickly loses his patience.
+	Nurse Joy comes out of her back room and informs Shadow that Riolu has been
+	healed; it is on top of a cart that Nurse Joy's Chansey is carrying. Riolu
+	climbs up onto Shadow's shoulder and says hello. As they're talking, a
+	different Trainer with a Vaporeon appears and talks about having battled
+	Entei a few minutes ago. Shadow says a hasty goodbye to his dad and exits
+	the Pok&#233;mon Center; other trainers exit as well; they're all looking
+	for Entei. After some searching in the forest, Shadow sees Entei standing
+	on top of a rock in a clearing. However, to his right is another trainer:
+	Verity! Armed with a Piplup, she too wants to fight Entei and the two race
+	to the clearing in hopes of being the first to battle. Once they make it,
+	though, they see a third trainer, named Sorrel, with a Lucario on the other
+	side of the clearing. All three of them try to fight Entei, but Entei
+	disdains the attack and flees to elsewhere. Shadow and Verity argue,
 	accusing each other of being the reason Entei fled, and the two agree to a
 	battle. Sorrel, on the other hand, refuses to fight, and leaves with his
 	Lucario, telling them that it's due to rain soon. Verity's Piplup's Hydro


### PR DESCRIPTION
Chapter 3 has been edited so that Shadow and Lucario are in the middle of a battle with Erika, the Celadon Gym leader, and after they beat her Tangela Riolu evolves into Lucario.
Of course, Riolu has been changed to Lucario for all chapters past 3.